### PR TITLE
breaking shared_ptr cycle

### DIFF
--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -59,8 +59,13 @@ namespace libp2p::connection {
 
     // this lambda checks, if there's enough data in our read buffer, and gives
     // it to the caller, if so
-    auto read_lambda = [self{shared_from_this()}, cb{std::move(cb)}, out, bytes,
+    auto read_lambda = [weak{weak_from_this()}, cb{std::move(cb)}, out, bytes,
                         some](outcome::result<size_t> res) mutable {
+      auto self = weak.lock();
+      if (!self) {
+	return cb(Error::STREAM_INTERNAL_ERROR);
+      }
+
       if (!res) {
         self->data_notified_ = true;
         return cb(res);


### PR DESCRIPTION
Running unit tests on cpp-libp2p compiled with `-DASAN=On` shows quite a few memory leaks in `all_muxers_acceptance_test` and `muxers_and_streams_test`. This fixes just one of them, decreasing the leak totals by 800 bytes in `all_muxers_acceptance_test` and 6002 bytes in  `muxers_and_streams_test`.