### PR TITLE
Fix to prevent segmentation fault when receiving empty protobuf message.

### DIFF
--- a/include/libp2p/basic/protobuf_message_read_writer.hpp
+++ b/include/libp2p/basic/protobuf_message_read_writer.hpp
@@ -46,6 +46,9 @@ namespace libp2p::basic {
             }
 
             auto &&buf = res.value();
+            if (!buf)
+              return cb(ProtoMsgType{});
+
             ProtoMsgType msg;
             msg.ParseFromArray(buf->data(), buf->size());
             if (bytes) {

--- a/include/libp2p/basic/protobuf_message_read_writer.hpp
+++ b/include/libp2p/basic/protobuf_message_read_writer.hpp
@@ -46,8 +46,9 @@ namespace libp2p::basic {
             }
 
             auto &&buf = res.value();
-            if (!buf)
+            if (!buf) {
               return cb(ProtoMsgType{});
+            }
 
             ProtoMsgType msg;
             msg.ParseFromArray(buf->data(), buf->size());


### PR DESCRIPTION
The problem occurs when there is a need to receive message like:

message BlockResponse {
    repeated bytes block_data = 1;
}

and block_data has zero length. According to protobuf standard 'repeated' means zero or more occurs so it is possible for message with only one repeated field to have no data.

Correct message is read in MessageReadWriterUvarint::read (message_read_writer_uvarint.cpp). If there is no error during read this method check if message length is zero and if so, it calls callback with ResultType:

`cb(ResultType{});`

But the result type is:
`using ResultType = std::shared_ptr<std::vector<uint8_t>>;`

In fact, the previous callback execution is done using shared pointer that contain nullptr.

Read method of ProtobufMessageReadWriter (protobuf_message_read_writer.hpp) contains lambda called from MessageReadWriter, which checks if result is correct and if so it executs the following code:

auto &&buf = res.value();
ProtoMsgType msg;
msg.ParseFromArray(buf->data(), buf->size());

So right after getting shared pointer (`res.value()`) it's dereferenced without checking if it's empty (`buf->data()`, `buf->size()`). This causes segmentation fault.